### PR TITLE
Fix document path timing issue in OakTextView -setDocument:

### DIFF
--- a/editorconfig-textmate/editorconfig-textmate-Info.plist
+++ b/editorconfig-textmate/editorconfig-textmate-Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2.5</string>
+	<string>0.2.6-beta</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>0.2.5</string>
+	<string>0.2.6-beta</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2012-2016 Rob Brackett. This is open source software and released under the MIT license.</string>
 	<key>NSPrincipalClass</key>

--- a/source/additions/NSView+EditorConfig.m
+++ b/source/additions/NSView+EditorConfig.m
@@ -20,11 +20,14 @@
 - (void)ec_setDocument:(id)document {
     [self ec_setDocument:document];
     
-    NSString *fileName = self.window.representedFilename;
+    NSString *fileName = [document valueForKey:@"path"];
     if (fileName == nil) {
-        fileName = [self.window.windowController representedFilename];
+        fileName = self.window.representedFilename;
         if (fileName == nil) {
-            fileName = @"";
+            fileName = [self.window.windowController representedFilename];
+            if (fileName == nil) {
+                fileName = @"";
+            }
         }
     }
     


### PR DESCRIPTION
Fixes #24.

Sometime recently, TextMate stopped updating the window's representedFilename synchronously as part of `OakTextView -setDocument:`, which means we started getting the path for the file that the user was switching *away from* instead of the one they were switching to!

Fortunately, TextMate has also added a nice ObjC OakDocument class since this code was last worked on (used to be a C++ class; hard to dynamically inspect), so we can now simply ask the document being set for its path. Much simpler :)

A future update should come back around and clear out the old code here that supports TM1 and older versions of TM2.