### PR TITLE
Add support for `max_line_length`

### DIFF
--- a/source/ECEditorConfig.m
+++ b/source/ECEditorConfig.m
@@ -127,7 +127,7 @@
     
     NSString *max_line_length = [config objectForKey:@"max_line_length"];
     if (max_line_length) {
-        [window ec_setWrapColumn:max_line_length.integerValue];
+        [window ec_setWrapColumn:max_line_length.intValue];
     }
     
     // TODO: end_of_line support

--- a/source/ECEditorConfig.m
+++ b/source/ECEditorConfig.m
@@ -125,6 +125,11 @@
         [window ec_setTabSize:[indent_size intValue]];
     }
     
+    NSString *max_line_length = [config objectForKey:@"max_line_length"];
+    if (max_line_length) {
+        [window ec_setWrapColumn:max_line_length.integerValue];
+    }
+    
     // TODO: end_of_line support
 }
 

--- a/source/additions/NSWindow+EditorConfig.h
+++ b/source/additions/NSWindow+EditorConfig.h
@@ -20,5 +20,6 @@
 
 - (BOOL)ec_setSoftTabs:(BOOL)softTabs;
 - (BOOL)ec_setTabSize:(int)tabSize;
+- (BOOL)ec_setWrapColumn:(int)wrapColumn;
 
 @end

--- a/source/additions/NSWindow+EditorConfig.m
+++ b/source/additions/NSWindow+EditorConfig.m
@@ -117,4 +117,22 @@
     return success;
 }
 
+- (BOOL)ec_setWrapColumn:(int)wrapColumn {
+    if (wrapColumn == 0) {
+        return NO;
+    }
+    
+    NSView *textView = self.ec_textView;
+    SEL wrapColumnSelector = @selector(setWrapColumn:);
+    
+    if ([textView respondsToSelector:wrapColumnSelector]) {
+        IMP setter = [textView methodForSelector:wrapColumnSelector];
+        setter(textView, wrapColumnSelector, wrapColumn);
+        DebugLog(@"(text view) Setting wrap column: %ld", (long)wrapColumn);
+        return YES;
+    }
+    
+    return NO;
+}
+
 @end


### PR DESCRIPTION
This isn’t quite exactly to spec, but follows the idea in #19 of mapping the `max_line_length` to the wrapping column in TextMate (there’s not really a built-in hard-wrapping feature, would be pretty complex and invasive).