### PR TITLE
Add support for `charset` and `end_of_line`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ The following Editor Config features are supported:
 - tab_width
 - insert_final_newline (newline is added when saving a document)
 - trim_trailing_whitespace (whitespace is trimmed when saving a document)
-
-The `end_of_line` and `charset` features are not yet supported (see #23 for updates).
+- end_of_line
+- charset (the charset `utf-8-bom` is not supported; if you need it, please [file an issue](https://github.com/Mr0grog/editorconfig-textmate/issues).)
 
 
 Installation

--- a/editorconfig-textmate.xcodeproj/project.pbxproj
+++ b/editorconfig-textmate.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		CB47C5E815C0876400E068C7 /* LICENSE in CopyFiles */ = {isa = PBXBuildFile; fileRef = CB47C5E315C0874C00E068C7 /* LICENSE */; };
 		CB60468716F6D0FE004753CD /* libeditorconfig_static.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CB60468616F6D0EC004753CD /* libeditorconfig_static.a */; };
 		CB993E4F1DDF797500D3050B /* NSObject+ECDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = CB993E4E1DDF797500D3050B /* NSObject+ECDocument.m */; };
+		CBE13DF31E206EA40069F96C /* ECSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = CBE13DF21E206EA40069F96C /* ECSettings.m */; };
 		CBFF551715C35A8E0075328B /* NSView+EditorConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = CBFF551615C35A8E0075328B /* NSView+EditorConfig.m */; };
 /* End PBXBuildFile section */
 
@@ -102,6 +103,8 @@
 		CB60468616F6D0EC004753CD /* libeditorconfig_static.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libeditorconfig_static.a; path = editorconfig/libeditorconfig_static.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB993E4D1DDF797500D3050B /* NSObject+ECDocument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+ECDocument.h"; sourceTree = "<group>"; };
 		CB993E4E1DDF797500D3050B /* NSObject+ECDocument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+ECDocument.m"; sourceTree = "<group>"; };
+		CBE13DF11E206EA40069F96C /* ECSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ECSettings.h; sourceTree = "<group>"; };
+		CBE13DF21E206EA40069F96C /* ECSettings.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ECSettings.m; sourceTree = "<group>"; };
 		CBFF551515C35A8E0075328B /* NSView+EditorConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSView+EditorConfig.h"; sourceTree = "<group>"; };
 		CBFF551615C35A8E0075328B /* NSView+EditorConfig.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSView+EditorConfig.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -206,6 +209,8 @@
 				CB47C5B915C0584300E068C7 /* TMPlugInController.h */,
 				CB47C5C515C05DC900E068C7 /* ECConstants.h */,
 				CB47C5C615C05DCA00E068C7 /* ECConstants.m */,
+				CBE13DF11E206EA40069F96C /* ECSettings.h */,
+				CBE13DF21E206EA40069F96C /* ECSettings.m */,
 			);
 			path = source;
 			sourceTree = SOURCE_ROOT;
@@ -254,7 +259,7 @@
 		CB47C58F15C0538700E068C7 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0430;
+				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = "Rob Brackett";
 			};
 			buildConfigurationList = CB47C59215C0538700E068C7 /* Build configuration list for PBXProject "editorconfig-textmate" */;
@@ -339,6 +344,7 @@
 				CB993E4F1DDF797500D3050B /* NSObject+ECDocument.m in Sources */,
 				CB47C5B715C057BE00E068C7 /* ECEditorConfig.m in Sources */,
 				CB47C5C015C05ABD00E068C7 /* NSObject+ECSwizzle.m in Sources */,
+				CBE13DF31E206EA40069F96C /* ECSettings.m in Sources */,
 				CB47C5C315C05BD800E068C7 /* NSWindow+EditorConfig.m in Sources */,
 				CB47C5C715C05DCA00E068C7 /* ECConstants.m in Sources */,
 				CBFF551715C35A8E0075328B /* NSView+EditorConfig.m in Sources */,
@@ -377,11 +383,21 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = NO;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -391,7 +407,9 @@
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = NO;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/lib/**";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
@@ -404,15 +422,27 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = NO;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = NO;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/lib/**";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
@@ -424,7 +454,9 @@
 		CB47C5AB15C0538800E068C7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_ENABLE_OBJC_ARC = NO;
+				CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "editorconfig-textmate/editorconfig-textmate-Prefix.pch";
 				HEADER_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)/**";
@@ -444,7 +476,9 @@
 		CB47C5AC15C0538800E068C7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_ENABLE_OBJC_ARC = NO;
+				CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "editorconfig-textmate/editorconfig-textmate-Prefix.pch";
 				HEADER_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)/**";

--- a/source/ECEditorConfig.h
+++ b/source/ECEditorConfig.h
@@ -14,7 +14,4 @@
 
 - (id)initWithPlugInController:(id <TMPlugInController>)aController;
 
-- (NSDictionary *)configForPath:(NSString *)filePath;
-- (NSDictionary *)configForURL:(NSURL *)fileURL;
-
 @end

--- a/source/ECEditorConfig.m
+++ b/source/ECEditorConfig.m
@@ -91,7 +91,6 @@
         [window ec_setSoftTabs:(config.indentStyle == ECIndentStyleSpace)];
     }
     
-    // TM doesn't differentiate between tab- and space-indent sizes
     if (config.indentSize > 0) {
         [window ec_setTabSize:config.indentSize];
     }

--- a/source/ECEditorConfig.m
+++ b/source/ECEditorConfig.m
@@ -99,9 +99,15 @@
         [window ec_setWrapColumn:config.maxLineLength];
     }
     
-    [window ec_setSettings:config forPath:nil];
+    if (config.endOfLine) {
+        [window ec_setNewline:config.endOfLine];
+    }
     
-    // TODO: end_of_line support
+    if (config.charset) {
+        [window ec_setEncoding:config.charset];
+    }
+    
+    [window ec_setSettings:config forPath:nil];
 }
 
 - (NSString *)editorConfigCoreVersion {

--- a/source/ECSettings.h
+++ b/source/ECSettings.h
@@ -1,0 +1,38 @@
+//
+//  ECSettings.h
+//  editorconfig-textmate
+//
+//  Copyright (c) 2012-2017 Rob Brackett.
+//  This is open source software, released under the MIT license;
+//  see the file LICENSE for details.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSUInteger, ECIndentStyle) {
+    ECIndentStyleUnknown,
+    ECIndentStyleSpace,
+    ECIndentStyleTab
+};
+
+/**
+ * Stores parsed .editorconfig settings. Property names match the .editorconfig
+ * names, but are camel-cased. "Unset" values are nil, 0, or Unknown.
+ */
+@interface ECSettings : NSObject <NSCopying>
+
+@property ECIndentStyle indentStyle;
+@property NSUInteger indentSize;
+@property (nonatomic, copy) NSString *endOfLine;
+@property (nonatomic, copy) NSString *charset;
+@property BOOL trimTrailingWhitespace;
+@property BOOL insertFinalNewline;
+@property NSUInteger maxLineLength;
+
+/**
+ * Read .editorconfig files relevant to the file at `path` and return an
+ * ECSettings instance with the correct values.
+ */
++ (instancetype)settingsForPath:(NSString *)path;
+
+@end

--- a/source/ECSettings.m
+++ b/source/ECSettings.m
@@ -62,10 +62,10 @@
                 charset = @"UTF-8";
             }
             else if ([value isEqualToString:@"utf-16be"]) {
-                charset = @"UTF-16BE";
+                charset = @"UTF-16BE//BOM";
             }
             else if ([value isEqualToString:@"utf-16le"]) {
-                charset = @"UTF-16LE";
+                charset = @"UTF-16LE//BOM";
             }
             else {
                 DebugLog(@"Unknown charset value: '%@'", value);

--- a/source/ECSettings.m
+++ b/source/ECSettings.m
@@ -1,0 +1,145 @@
+//
+//  ECSettings.m
+//  editorconfig-textmate
+//
+//  Copyright (c) 2012-2017 Rob Brackett.
+//  This is open source software, released under the MIT license;
+//  see the file LICENSE for details.
+//
+
+#import <editorconfig/editorconfig_handle.h>
+#import <editorconfig/editorconfig.h>
+#import "ECConstants.h"
+#import "ECSettings.h"
+
+
+@implementation ECSettings
+
+#pragma mark - Parsing/instantiation
+
++ (instancetype)settingsForPath:(NSString *)path {
+    ECSettings *settings = [[ECSettings alloc] init];
+    
+    [self enumerateSettingsForPath:path withBlock:^(NSString *name, NSString *value) {
+        if ([name isEqualToString:@"indent_style"]) {
+            ECIndentStyle indentStyle = ECIndentStyleUnknown;
+            if ([value isEqualToString:@"space"]) {
+                indentStyle = ECIndentStyleSpace;
+            }
+            else if ([value isEqualToString:@"tab"]) {
+                indentStyle = ECIndentStyleTab;
+            }
+            else {
+                DebugLog(@"Unknown indent_style value: '%@'", value);
+            }
+            settings.indentStyle = indentStyle;
+        }
+        else if ([name isEqualToString:@"indent_size"] || [name isEqualToString:@"tab_width"]) {
+            settings.indentSize = [value integerValue];
+        }
+        else if ([name isEqualToString:@"end_of_line"]) {
+            NSString *endOfLine = nil;
+            if ([value isEqualToString:@"lf"]) {
+                endOfLine = @"\n";
+            }
+            else if ([value isEqualToString:@"cr"]) {
+                endOfLine = @"\r";
+            }
+            else if ([value isEqualToString:@"crlf"]) {
+                endOfLine = @"\r\n";
+            }
+            else {
+                DebugLog(@"Unknown end_of_line value: '%@'", value);
+            }
+            settings.endOfLine = endOfLine;
+        }
+        else if ([name isEqualToString:@"charset"]) {
+            NSString *charset = nil;
+            if ([value isEqualToString:@"latin1"]) {
+                charset = @"ISO-8859-1";
+            }
+            else if ([value isEqualToString:@"utf-8"]) {
+                charset = @"UTF-8";
+            }
+            else if ([value isEqualToString:@"utf-16be"]) {
+                charset = @"UTF-16BE";
+            }
+            else if ([value isEqualToString:@"utf-16le"]) {
+                charset = @"UTF-16LE";
+            }
+            else {
+                DebugLog(@"Unknown charset value: '%@'", value);
+            }
+            settings.charset = charset;
+        }
+        else if ([name isEqualToString:@"trim_trailing_whitespace"]) {
+            settings.trimTrailingWhitespace = [value isEqualToString:@"true"];
+        }
+        else if ([name isEqualToString:@"insert_final_newline"]) {
+            settings.insertFinalNewline = [value isEqualToString:@"true"];
+        }
+        else if ([name isEqualToString:@"max_line_length"]) {
+            settings.indentSize = [value integerValue];
+        }
+        else {
+            DebugLog(@"Unknown setting: '%@'", name);
+        }
+    }];
+        
+    return [settings autorelease];
+}
+
++ (void)enumerateSettingsForPath:(NSString *)path withBlock:(void (^)(NSString *name, NSString *value))block {
+    editorconfig_handle handle = editorconfig_handle_init();
+    int resultCode = editorconfig_parse([path UTF8String], handle);
+    if (resultCode == 0) {
+        int itemCount = editorconfig_handle_get_name_value_count(handle);
+        for (int i = 0; i < itemCount; i++) {
+            char const *name;
+            char const *value;
+            editorconfig_handle_get_name_value(handle, i, &name, &value);
+            block([NSString stringWithUTF8String:name],
+                  [NSString stringWithUTF8String:value]);
+        }
+    }
+    editorconfig_handle_destroy(handle);
+}
+
+
+#pragma mark - Lifecycle
+
+- (id)init {
+    if(self = [super init]) {
+        self.indentStyle = ECIndentStyleUnknown;
+        self.indentSize = 0;
+        self.endOfLine = nil;
+        self.charset = nil;
+        self.trimTrailingWhitespace = NO;
+        self.insertFinalNewline = NO;
+        self.maxLineLength = 0;
+    }
+    return self;
+}
+
+- (void)dealloc {
+    self.endOfLine = nil;
+    self.charset = nil;
+    [super dealloc];
+}
+
+- (id)copyWithZone:(NSZone *)zone {
+    ECSettings *copy = [[self class] allocWithZone:zone];
+    
+    copy.indentStyle = self.indentStyle;
+    copy.indentSize = self.indentSize;
+    copy.endOfLine = self.endOfLine;
+    copy.charset = self.charset;
+    copy.trimTrailingWhitespace = self.trimTrailingWhitespace;
+    copy.insertFinalNewline = self.insertFinalNewline;
+    copy.maxLineLength = self.maxLineLength;
+    
+    return copy;
+}
+
+
+@end

--- a/source/additions/NSObject+ECDocument.h
+++ b/source/additions/NSObject+ECDocument.h
@@ -14,9 +14,14 @@
  * This category lets us associate EditorConfig settings directly with an
  * OakDocument (TextMate's document class). This allows us to get settings
  * immediately in order to modify documents when they are about to save.
+ * 
+ * TODO: should this project define an OakDocument interface and add this
+ * catgory to that?
  */
 @interface NSObject (ECDocument)
 
 @property (nonatomic, copy) ECSettings *ec_settings;
+@property (nonatomic) NSString* diskEncoding;
+@property (nonatomic) NSString* diskNewlines;
 
 @end

--- a/source/additions/NSObject+ECDocument.h
+++ b/source/additions/NSObject+ECDocument.h
@@ -7,6 +7,8 @@
 //  see the file LICENSE for details.
 //
 
+#import "ECSettings.h"
+
 
 /**
  * This category lets us associate EditorConfig settings directly with an
@@ -15,6 +17,6 @@
  */
 @interface NSObject (ECDocument)
 
-@property (nonatomic, copy) NSDictionary *ec_settings;
+@property (nonatomic, copy) ECSettings *ec_settings;
 
 @end

--- a/source/additions/NSObject+ECDocument.m
+++ b/source/additions/NSObject+ECDocument.m
@@ -12,6 +12,10 @@
 
 @implementation NSObject (ECDocument)
 
+// These are defined in OakDocument
+@dynamic diskEncoding;
+@dynamic diskNewlines;
+
 - (void)setEc_settings:(ECSettings *)ec_settings {
     objc_setAssociatedObject(self, @selector(ec_settings), ec_settings, OBJC_ASSOCIATION_COPY_NONATOMIC);
 }

--- a/source/additions/NSObject+ECDocument.m
+++ b/source/additions/NSObject+ECDocument.m
@@ -12,13 +12,13 @@
 
 @implementation NSObject (ECDocument)
 
-- (void)setEc_settings:(NSDictionary *)ec_settings {
+- (void)setEc_settings:(ECSettings *)ec_settings {
     objc_setAssociatedObject(self, @selector(ec_settings), ec_settings, OBJC_ASSOCIATION_COPY_NONATOMIC);
 }
 
-- (NSDictionary *)ec_settings {
+- (ECSettings *)ec_settings {
     id settings = objc_getAssociatedObject(self, @selector(ec_settings));
-    if (![settings isKindOfClass:[NSDictionary class]]) {
+    if (![settings isKindOfClass:[ECSettings class]]) {
         settings = nil;
     }
     return settings;

--- a/source/additions/NSView+EditorConfig.m
+++ b/source/additions/NSView+EditorConfig.m
@@ -53,11 +53,8 @@
 #pragma mark - Private
 
 - (void)ec_applySettingsToDocument:(NSObject *)document {
-    NSDictionary *settings = document.ec_settings;
-    BOOL insertFinalNewline = [[settings objectForKey:@"insert_final_newline"] isEqualToString:@"true"];
-    BOOL trimTrailingWhitespace = [[settings objectForKey:@"trim_trailing_whitespace"] isEqualToString:@"true"];
-    
-    if (!(insertFinalNewline || trimTrailingWhitespace)) {
+    ECSettings *settings = document.ec_settings;
+    if (!(settings.insertFinalNewline || settings.trimTrailingWhitespace)) {
         return;
     }
     
@@ -70,13 +67,13 @@
         lineTerminator = @"\n";
     }
     
-    if (insertFinalNewline && ![content hasSuffix:lineTerminator]) {
+    if (settings.insertFinalNewline && ![content hasSuffix:lineTerminator]) {
         content = [content stringByAppendingString:lineTerminator];
         didChangeContent = YES;
     }
     
     // TODO: find a reasonable way to encapsulate all the logic here.
-    if (trimTrailingWhitespace) {
+    if (settings.trimTrailingWhitespace) {
         NSMutableString *newContent = [NSMutableString string];
         // Selections are an NSArray of NSValues boxing NSRanges
         // FIXME: this approach collapses column selections into a single contiguous range. Not sure on a better approach for now.

--- a/source/additions/NSWindow+EditorConfig.h
+++ b/source/additions/NSWindow+EditorConfig.h
@@ -25,5 +25,7 @@
 - (BOOL)ec_setSoftTabs:(BOOL)softTabs;
 - (BOOL)ec_setTabSize:(NSUInteger)tabSize;
 - (BOOL)ec_setWrapColumn:(NSUInteger)wrapColumn;
+- (BOOL)ec_setNewline:(NSString *)newlineString;
+- (BOOL)ec_setEncoding:(NSString *)encoding;
 
 @end

--- a/source/additions/NSWindow+EditorConfig.h
+++ b/source/additions/NSWindow+EditorConfig.h
@@ -8,6 +8,7 @@
 //
 
 #import <Cocoa/Cocoa.h>
+#import "ECSettings.h"
 
 // Because TM doesn't have a nice API, we have to mess with NSWindow :(
 @interface NSWindow (EditorConfig)
@@ -19,10 +20,10 @@
 // sends a kECDocumentDidChange notification
 - (void)ec_setRepresentedFilename:(NSString *)fileName;
 
-- (void)ec_setSettings:(NSDictionary *)settings forPath:(NSString *)path;
+- (void)ec_setSettings:(ECSettings *)settings forPath:(NSString *)path;
 
 - (BOOL)ec_setSoftTabs:(BOOL)softTabs;
-- (BOOL)ec_setTabSize:(int)tabSize;
-- (BOOL)ec_setWrapColumn:(int)wrapColumn;
+- (BOOL)ec_setTabSize:(NSUInteger)tabSize;
+- (BOOL)ec_setWrapColumn:(NSUInteger)wrapColumn;
 
 @end

--- a/source/additions/NSWindow+EditorConfig.m
+++ b/source/additions/NSWindow+EditorConfig.m
@@ -75,7 +75,7 @@
 
 #pragma mark - Commands
 
-- (void)ec_setSettings:(NSDictionary *)settings forPath:(NSString *)path {
+- (void)ec_setSettings:(ECSettings *)settings forPath:(NSString *)path {
     NSView *textView = self.ec_textView;
     NSObject *document = [textView performSelector:@selector(document)];
     if (document && (!path || [path isEqualToString:[document valueForKey:@"path"]])) {
@@ -108,7 +108,7 @@
     return success;
 }
 
-- (BOOL)ec_setTabSize:(int)tabSize {
+- (BOOL)ec_setTabSize:(NSUInteger)tabSize {
     BOOL success = NO;
     
     if (tabSize > 0) {
@@ -118,7 +118,7 @@
         if ([textView respondsToSelector:tabSizeSelector]) {
             IMP setter = [textView methodForSelector:tabSizeSelector];
             setter(textView, tabSizeSelector, tabSize);
-            DebugLog(@"(text view) Setting tab size: %d", tabSize);
+            DebugLog(@"(text view) Setting tab size: %ld", tabSize);
             success = YES;
         }
         
@@ -126,7 +126,7 @@
         if ([statusBar respondsToSelector:tabSizeSelector]) {
             IMP setter = [statusBar methodForSelector:tabSizeSelector];
             setter(statusBar, tabSizeSelector, tabSize);
-            DebugLog(@"(status bar) Setting tab size: %d", tabSize);
+            DebugLog(@"(status bar) Setting tab size: %ld", tabSize);
         }
         else {
             success = NO;
@@ -136,7 +136,7 @@
     return success;
 }
 
-- (BOOL)ec_setWrapColumn:(int)wrapColumn {
+- (BOOL)ec_setWrapColumn:(NSUInteger)wrapColumn {
     if (wrapColumn == 0) {
         return NO;
     }

--- a/source/additions/NSWindow+EditorConfig.m
+++ b/source/additions/NSWindow+EditorConfig.m
@@ -154,4 +154,25 @@
     return NO;
 }
 
+- (BOOL)ec_setNewline:(NSString *)newlineString {
+    NSView *textView = self.ec_textView;
+    NSObject *document = [textView performSelector:@selector(document)];
+    if (document) {
+        document.diskNewlines = newlineString;
+        return YES;
+    }
+    return NO;
+}
+
+- (BOOL)ec_setEncoding:(NSString *)encoding {
+    NSView *textView = self.ec_textView;
+    NSObject *document = [textView performSelector:@selector(document)];
+    if (document) {
+        document.diskEncoding = encoding;
+        return YES;
+    }
+    return NO;
+}
+
+
 @end


### PR DESCRIPTION
Finally: add support for the last missing official EditorConfig features, `end_of_line` and `charset`. All the values listed on the EditorConfig documentation: https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties.

Note the charset `utf-8-bom` is not supported—it is listed but discouraged on the EditorConfig homepage, but not listed at all in the actual docs.

Fixes #23. Depends on #29.