### PR TITLE
Remove hacky bundle name, fix copyright headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2016 Rob Brackett
+Copyright (c) 2012-2017 Rob Brackett
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/editorconfig-textmate/editorconfig-textmate-Info.plist
+++ b/editorconfig-textmate/editorconfig-textmate-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>com.macromates.HACK.org.robbrackett.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>org.robbrackett.${PRODUCT_NAME:rfc1034identifier}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/source/ECConstants.h
+++ b/source/ECConstants.h
@@ -2,7 +2,7 @@
 //  ECConstants.h
 //  editorconfig-textmate
 //
-//  Copyright (c) 2012-2016 Rob Brackett.
+//  Copyright (c) 2012-2017 Rob Brackett.
 //  This is open source software, released under the MIT license;
 //  see the file LICENSE for details.
 //

--- a/source/ECConstants.m
+++ b/source/ECConstants.m
@@ -2,7 +2,7 @@
 //  ECConstants.m
 //  editorconfig-textmate
 //
-//  Copyright (c) 2012-2016 Rob Brackett.
+//  Copyright (c) 2012-2017 Rob Brackett.
 //  This is open source software, released under the MIT license;
 //  see the file LICENSE for details.
 //

--- a/source/ECEditorConfig.h
+++ b/source/ECEditorConfig.h
@@ -2,7 +2,7 @@
 //  EditorConfig.h
 //  editorconfig-textmate
 //
-//  Copyright (c) 2012-2016 Rob Brackett.
+//  Copyright (c) 2012-2017 Rob Brackett.
 //  This is open source software, released under the MIT license;
 //  see the file LICENSE for details.
 //

--- a/source/ECEditorConfig.m
+++ b/source/ECEditorConfig.m
@@ -2,7 +2,7 @@
 //  EditorConfig.m
 //  editorconfig-textmate
 //
-//  Copyright (c) 2012-2016 Rob Brackett.
+//  Copyright (c) 2012-2017 Rob Brackett.
 //  This is open source software, released under the MIT license;
 //  see the file LICENSE for details.
 //

--- a/source/TMPlugInController.h
+++ b/source/TMPlugInController.h
@@ -2,7 +2,7 @@
 //  TMPlugInController.h
 //  editorconfig-textmate
 //
-//  Copyright (c) 2012-2016 Rob Brackett.
+//  Copyright (c) 2012-2017 Rob Brackett.
 //  This is open source software, released under the MIT license;
 //  see the file LICENSE for details.
 //

--- a/source/additions/NSObject+ECDocument.h
+++ b/source/additions/NSObject+ECDocument.h
@@ -2,7 +2,7 @@
 //  NSObject+ECDocument.h
 //  editorconfig-textmate
 //
-//  Copyright © 2016 Rob Brackett.
+//  Copyright (c) 2012-2017 Rob Brackett.
 //  This is open source software, released under the MIT license;
 //  see the file LICENSE for details.
 //

--- a/source/additions/NSObject+ECDocument.m
+++ b/source/additions/NSObject+ECDocument.m
@@ -2,7 +2,7 @@
 //  NSObject+ECDocument.m
 //  editorconfig-textmate
 //
-//  Copyright © 2016 Rob Brackett
+//  Copyright (c) 2012-2017 Rob Brackett.
 //  This is open source software, released under the MIT license;
 //  see the file LICENSE for details.
 //

--- a/source/additions/NSObject+ECSwizzle.h
+++ b/source/additions/NSObject+ECSwizzle.h
@@ -2,7 +2,7 @@
 //  NSObject+ECSwizzle.h
 //  editorconfig-textmate
 //
-//  Copyright (c) 2012 Rob Brackett.
+//  Copyright (c) 2012-2017 Rob Brackett.
 //  This is open source software, released under the MIT license;
 //  see the file LICENSE for details.
 //

--- a/source/additions/NSObject+ECSwizzle.m
+++ b/source/additions/NSObject+ECSwizzle.m
@@ -2,7 +2,7 @@
 //  NSObject+ECSwizzle.m
 //  editorconfig-textmate
 //
-//  Copyright (c) 2012 Rob Brackett.
+//  Copyright (c) 2012-2017 Rob Brackett.
 //  This is open source software, released under the MIT license;
 //  see the file LICENSE for details.
 //

--- a/source/additions/NSView+EditorConfig.h
+++ b/source/additions/NSView+EditorConfig.h
@@ -2,7 +2,7 @@
 //  NSView+EditorConfig.h
 //  editorconfig-textmate
 //
-//  Copyright (c) 2012 Rob Brackett.
+//  Copyright (c) 2012-2017 Rob Brackett.
 //  This is open source software, released under the MIT license;
 //  see the file LICENSE for details.
 //

--- a/source/additions/NSView+EditorConfig.m
+++ b/source/additions/NSView+EditorConfig.m
@@ -2,7 +2,7 @@
 //  NSView+EditorConfig.m
 //  editorconfig-textmate
 //
-//  Copyright (c) 2012 Rob Brackett.
+//  Copyright (c) 2012-2017 Rob Brackett.
 //  This is open source software, released under the MIT license;
 //  see the file LICENSE for details.
 //

--- a/source/additions/NSWindow+EditorConfig.h
+++ b/source/additions/NSWindow+EditorConfig.h
@@ -2,7 +2,7 @@
 //  NSWindow+EditorConfig.h
 //  editorconfig-textmate
 //
-//  Copyright (c) 2012 Rob Brackett.
+//  Copyright (c) 2012-2017 Rob Brackett.
 //  This is open source software, released under the MIT license;
 //  see the file LICENSE for details.
 //

--- a/source/additions/NSWindow+EditorConfig.m
+++ b/source/additions/NSWindow+EditorConfig.m
@@ -2,7 +2,7 @@
 //  NSWindow+EditorConfig.m
 //  editorconfig-textmate
 //
-//  Copyright (c) 2012 Rob Brackett.
+//  Copyright (c) 2012-2017 Rob Brackett.
 //  This is open source software, released under the MIT license;
 //  see the file LICENSE for details.
 //


### PR DESCRIPTION
The main thing here is removing the `com.macromates.HACK.` prefix from the bundle identifier. It was originally added because TextMate 2 would only accept plugin bundles from `com.macromates`, but that issue has since been fixed and this horrible ID is no longer needed.

While I was at it, I also fixed all the copyright dates throughout the codebase.