### PR TITLE
Fix `max_line_length` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The following Editor Config features are supported:
 - trim_trailing_whitespace (whitespace is trimmed when saving a document)
 - end_of_line
 - charset (the charset `utf-8-bom` is not supported; if you need it, please [file an issue](https://github.com/Mr0grog/editorconfig-textmate/issues).)
+- max_line_length (sets TextMate’s “wrap column,” but does not necessarily trigger hard line wraps)
 
 
 Installation

--- a/source/ECSettings.m
+++ b/source/ECSettings.m
@@ -79,7 +79,7 @@
             settings.insertFinalNewline = [value isEqualToString:@"true"];
         }
         else if ([name isEqualToString:@"max_line_length"]) {
-            settings.indentSize = [value integerValue];
+            settings.maxLineLength = [value integerValue];
         }
         else {
             DebugLog(@"Unknown setting: '%@'", name);


### PR DESCRIPTION
Looks like I broke this when refactoring parsing and configuration into its own `ECSettings` object :(

Also document the fact that this feature is supported. (How did I miss that??)