### PR TITLE
Upgrade pcre2 to v10.44

### DIFF
--- a/lib/pcre2/build-pcre2.sh
+++ b/lib/pcre2/build-pcre2.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # 
 # If you don't set an output path, it will use `./build`.
 
-VERSION='10.40'
+VERSION='10.44'
 PCRE2_DIR=$(cd $(dirname $0) && pwd)
 SOURCE_PATH="${PCRE2_DIR}/pcre2-${VERSION}"
 BUILD_PATH="${1:-"${PCRE2_DIR}/build"}"


### PR DESCRIPTION
This upgrades pcre2 from v10.40 to v10.44, which includes better unicode support along with a bunch of minor updates and bugfixes.

- Summary release notes: https://github.com/PCRE2Project/pcre2/blob/6ae58beca071f13ccfed31d03b3f479ab520639b/NEWS
- Changelog: https://github.com/PCRE2Project/pcre2/blob/6ae58beca071f13ccfed31d03b3f479ab520639b/ChangeLog