### PR TITLE
Build with PCRE2 v10.46

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -6,4 +6,4 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-This code relies on the "editorconfig-core" and "pcre" libraries. Their licenses can be found in the files "LICENSE-editorconfig-core" and "LICENSE-pcre".
+This code relies on the "editorconfig-core" and "pcre" libraries. Their licenses can be found in the files "LICENSE-editorconfig-core" and "LICENSE-pcre.md".

--- a/editorconfig-textmate.xcodeproj/project.pbxproj
+++ b/editorconfig-textmate.xcodeproj/project.pbxproj
@@ -350,7 +350,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cp \"$BUILT_PRODUCTS_DIR/editorconfig/LICENSE\" \"$BUILT_PRODUCTS_DIR/$WRAPPER_NAME/Contents/Resources/LICENSE-editorconfig-core\"\ncp \"$BUILT_PRODUCTS_DIR/pcre2/LICENCE\" \"$BUILT_PRODUCTS_DIR/$WRAPPER_NAME/Contents/Resources/LICENSE-pcre\"\n";
+			shellScript = "cp \"$BUILT_PRODUCTS_DIR/editorconfig/LICENSE\" \"$BUILT_PRODUCTS_DIR/$WRAPPER_NAME/Contents/Resources/LICENSE-editorconfig-core\"\ncp \"$BUILT_PRODUCTS_DIR/pcre2/LICENCE.md\" \"$BUILT_PRODUCTS_DIR/$WRAPPER_NAME/Contents/Resources/LICENSE-pcre.md\"\n";
 		};
 		CB60467916F6B558004753CD /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/lib/pcre2/build-pcre2.sh
+++ b/lib/pcre2/build-pcre2.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # 
 # If you don't set an output path, it will use `./build`.
 
-VERSION='10.44'
+VERSION='10.46'
 PCRE2_DIR=$(cd $(dirname $0) && pwd)
 SOURCE_PATH="${PCRE2_DIR}/pcre2-${VERSION}"
 BUILD_PATH="${1:-"${PCRE2_DIR}/build"}"
@@ -36,7 +36,7 @@ CFLAGS='-arch x86_64 -arch arm64 -mmacosx-version-min=11.0' ./configure \
   --prefix "${BUILD_PATH}"
 make
 make install
-cp "${SOURCE_PATH}/LICENCE" "${BUILD_PATH}/LICENCE"
+cp "${SOURCE_PATH}/LICENCE.md" "${BUILD_PATH}/LICENCE.md"
 
 # Verify architectures
 ARCHITECTURES="$(lipo -info "${BUILD_PATH}/lib/libpcre2-8.a")"


### PR DESCRIPTION
This upgrades the version of PCRE2 we use to v10.46, which was released last week. The only major difference for us is that the license file was renamed from `LICENCE` to `LICENCE.md`. Otherwise everything seems to work fine.

I’m not planning to cut a new release for this since there are no user-visible changes and, though it solves a vulnerability that was introduced in PCRE2 v10.45, we never used or published a release with that version. But this upgrade will come along for the ride in the next release here.

Fixes #57.